### PR TITLE
Fixed a problem where sess.mux caused panic with nil

### DIFF
--- a/gae_memcache_store.go
+++ b/gae_memcache_store.go
@@ -213,10 +213,10 @@ func (s *memcacheStore) Get(id string) Session {
 		return nil
 	}
 
-	// Yes! We have it! "Actualize" it.
-	sess.Access()
 	// Mutex is not marshalled, so create a new one:
 	sess.mux = &sync.RWMutex{}
+	// Yes! We have it! "Actualize" it.
+	sess.Access()
 	s.sessions[id] = sess
 	return sess
 }


### PR DESCRIPTION
Fixed a problem where sess.mux caused panic with nil in Access()
However, I do not know whether this is due to the design or not, so make sure to check. :) 
