### PR TITLE
Compatible for Go 1.11 or later

### DIFF
--- a/gae_memcache_store.go
+++ b/gae_memcache_store.go
@@ -1,5 +1,3 @@
-// +build appengine
-
 /*
 
 A Google App Engine Memcache session store implementation.
@@ -33,11 +31,11 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
-	"google.golang.org/appengine/memcache"
-	"golang.org/x/net/context"
 	"google.golang.org/appengine/log"
+	"google.golang.org/appengine/memcache"
 )
 
 // A Google App Engine Memcache session store implementation.

--- a/gae_session_demo/gae_session_demo.go
+++ b/gae_session_demo/gae_session_demo.go
@@ -1,5 +1,3 @@
-// +build appengine
-
 /*
 This is a session demo application that can be run on Google AppEngine platform.
 You can also try it locally by running 'goapp serve' from this folder.


### PR DESCRIPTION
I am currently rewriting the project for Go 1.11 Modules, but the + build tag is no longer available.
The appengine package is not required, so it is no longer necessary to classify builds by build tags.

Regards. 
Thank you.